### PR TITLE
Add headers to zig package

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,6 +5,7 @@
         "build.zig",
         "build.zig.zon",
         "src",
+        "libs",
         "README.md",
         "LICENSE",
     },


### PR DESCRIPTION
Hello!

This adds `SDL.h` and friends to the Zig package manager definition.

This is needed for adding an SDL backend to zgui (because imgui expects the header files to exist).

See also: https://github.com/zig-gamedev/zgui/pull/8