### PR TITLE
in sdl3 found 2 functions that takes Rect type instead of FRect.

### DIFF
--- a/src/sdl3.zig
+++ b/src/sdl3.zig
@@ -499,15 +499,15 @@ pub const Renderer = opaque {
     }
     extern fn SDL_RenderPoint(renderer: *Renderer, x: f32, y: f32) c_int;
 
-    pub fn fillRect(renderer: *Renderer, _rect: Rect) Error!void {
+    pub fn fillRect(renderer: *Renderer, _rect: FRect) Error!void {
         if (SDL_RenderFillRect(renderer, &_rect) == False) return makeError();
     }
-    extern fn SDL_RenderFillRect(renderer: ?*Renderer, rect: *const Rect) c_int;
+    extern fn SDL_RenderFillRect(renderer: ?*Renderer, rect: *const FRect) c_int;
 
-    pub fn rect(renderer: *Renderer, _rect: Rect) Error!void {
+    pub fn rect(renderer: *Renderer, _rect: FRect) Error!void {
         if (SDL_RenderRect(renderer, &_rect) == False) return makeError();
     }
-    extern fn SDL_RenderRect(renderer: *Renderer, rect: *const Rect) c_int;
+    extern fn SDL_RenderRect(renderer: *Renderer, rect: *const FRect) c_int;
 
     pub fn drawGeometry(
         r: *Renderer,


### PR DESCRIPTION
SDL_RenderFillRect and SDL_RenderRect in SDL3 takes in type SDL_FRect* whereas sdl3.zig function takes on Rect* which is used
with integers. this caused passing this parameter to the function to be read incorrectly and missplace the rectangle based on the bit value of the original integers but presented as floats due to how the SDL3 function reads the data. 