### PR TITLE
Fix padding size in Event

### DIFF
--- a/src/sdl3.zig
+++ b/src/sdl3.zig
@@ -1771,7 +1771,7 @@ pub const Event = extern union {
     render: RenderEvent,
     drop: DropEvent,
     clipboard: ClipboardEvent,
-    _: u128, // padding
+    _: [128]u8, // padding
 };
 
 /// Pump the event loop, gathering events from the input devices.


### PR DESCRIPTION
I was getting an Illegal instruction error after my program ended normally, and during troubleshooting I noticed the Event union differed that what Zig translate-c was generating.

According to SDL_events.h, the [SDL_Event union has 128 bytes of padding](https://github.com/libsdl-org/SDL/blob/8eb57c5a420426f7b6d96f9c6afd0777c6137be6/include/SDL3/SDL_events.h#L1040), but our Event has 128 bits.

After making this change, my program no longer crashes.