### PR TITLE
Update render function params to floating point

### DIFF
--- a/src/sdl3.zig
+++ b/src/sdl3.zig
@@ -532,25 +532,25 @@ extern fn SDL_RenderPresent(r: *Renderer) void;
 pub fn renderTexture(
     r: *Renderer,
     tex: *Texture,
-    src: ?*const Rect,
-    dst: ?*const Rect,
+    src: ?*const FRect,
+    dst: ?*const FRect,
 ) Error!void {
     if (SDL_RenderTexture(r, tex, src, dst) == False) return makeError();
 }
 extern fn SDL_RenderTexture(
     r: *Renderer,
     t: *Texture,
-    srcrect: ?*const Rect,
-    dstrect: ?*const Rect,
+    srcrect: ?*const FRect,
+    dstrect: ?*const FRect,
 ) c_int;
 
 pub fn renderTextureRotated(
     r: *Renderer,
     tex: *Texture,
-    src: ?*const Rect,
-    dst: ?*const Rect,
+    src: ?*const FRect,
+    dst: ?*const FRect,
     angle: f64,
-    center: ?*const Point,
+    center: ?*const FPoint,
     flip: Surface.FlipMode,
 ) Error!void {
     if (SDL_RenderTextureRotated(r, tex, src, dst, angle, center, flip) == False) return makeError();
@@ -558,10 +558,10 @@ pub fn renderTextureRotated(
 extern fn SDL_RenderTextureRotated(
     r: *Renderer,
     t: *Texture,
-    srcrect: ?*const Rect,
-    dstrect: ?*const Rect,
+    srcrect: ?*const FRect,
+    dstrect: ?*const FRect,
     angle: f64,
-    center: ?*const Point,
+    center: ?*const FPoint,
     flip: Surface.FlipMode,
 ) c_int;
 


### PR DESCRIPTION
I discovered that specifying a src and/or dst `Rect` to renderTexture made it stop rendering at all for me, and noticed certain render [functions in SDL3](https://wiki.libsdl.org/SDL3/SDL_RenderTexture) now support subpixel resolution and expect `FRect`s and `FPoint`s instead of integer `Rect`s and `Point`s in SDL2. I did a quick pass and I think the rest of the render related functions are correct (with some missing which I'll add in another PR)