### PR TITLE
fixing opengl context destroy (SDL2 -> SDL3)

### DIFF
--- a/src/sdl3.zig
+++ b/src/sdl3.zig
@@ -355,8 +355,8 @@ pub const gl = struct {
     }
     extern fn SDL_GL_MakeCurrent(window: *Window, context: Context) c_int;
 
-    pub const deleteContext = SDL_GL_DeleteContext;
-    extern fn SDL_GL_DeleteContext(context: Context) void;
+    pub const destroyContext = SDL_GL_DestroyContext;
+    extern fn SDL_GL_DestroyContext(context: Context) void;
 };
 
 //--------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Opengl Context destruction in sdl3 has been renamed.

Thanks for your hard work <3